### PR TITLE
Fixes "TypeError: object is not a function"

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function RiotCompiler (inputTree, options) {
 }
 
 function compile (filepath) {
-  return { name: filepath, content: riotCompiler(fs.readFileSync(filepath, 'utf-8')) };
+  return { name: filepath, content: riotCompiler.compile(fs.readFileSync(filepath, 'utf-8')) };
 }
 
 function isTagFile (filepath) {


### PR DESCRIPTION
Installing this plugin with riot `^2.0.1` specified in `package.json` has pulled in riot version `2.0.14` for me. This causes the error `TypeError: object is not a function` to be thrown since `require('riot/compiler')` returns an object containing the top level riot methods, not the compile method. This fix simply calls `riotCompiler.compile` rather than attempting to call an object as if it was a function.
